### PR TITLE
Rewrite to put workaround within pubsub package

### DIFF
--- a/internal/pubsub/connection_test.go
+++ b/internal/pubsub/connection_test.go
@@ -24,7 +24,7 @@ func Test_E2E(t *testing.T) {
 
 	u, _ := url.Parse(s.URL)
 
-	c, err := NewConnection(Config{
+	c, err := NewInternalConnection(Config{
 		GroupID: "test-client",
 		Domain:  u.Host,
 		APIKeyProvider: func() ([]byte, error) {
@@ -117,7 +117,7 @@ func Test_ConnectionError(t *testing.T) {
 
 	u, _ := url.Parse(s.URL)
 
-	c, err := NewConnection(Config{
+	c, err := NewInternalConnection(Config{
 		GroupID: "test-client",
 		Domain:  u.Host,
 		APIKeyProvider: func() ([]byte, error) {
@@ -137,7 +137,7 @@ func Test_ConnectionError(t *testing.T) {
 }
 
 func Test_ConnectionMissingAppName(t *testing.T) {
-	c, err := NewConnection(Config{
+	c, err := NewInternalConnection(Config{
 		Domain: "example.com", // doesn't matter for this case
 		APIKeyProvider: func() ([]byte, error) {
 			return []byte("xyz"), nil
@@ -149,7 +149,7 @@ func Test_ConnectionMissingAppName(t *testing.T) {
 }
 
 func Test_ConnectionMissingDomain(t *testing.T) {
-	c, err := NewConnection(Config{
+	c, err := NewInternalConnection(Config{
 		GroupID: "test-app",
 		APIKeyProvider: func() ([]byte, error) {
 			return []byte("xyz"), nil
@@ -161,7 +161,7 @@ func Test_ConnectionMissingDomain(t *testing.T) {
 }
 
 func Test_ConnectionMissingAuthProvider(t *testing.T) {
-	c, err := NewConnection(Config{
+	c, err := NewInternalConnection(Config{
 		GroupID: "test-app",
 		Domain:  "example.com", // doesn't matter for this case
 	})
@@ -172,7 +172,7 @@ func Test_ConnectionMissingAuthProvider(t *testing.T) {
 
 func Test_AuthProviders(t *testing.T) {
 	t.Run("ApiKeyTest", func(t *testing.T) {
-		c, err := NewConnection(Config{
+		c, err := NewInternalConnection(Config{
 			GroupID: "test-app",
 			Domain:  "example.com", // doesn't matter for this case
 			APIKeyProvider: func() ([]byte, error) {
@@ -189,7 +189,7 @@ func Test_AuthProviders(t *testing.T) {
 	})
 
 	t.Run("AuthTokenTest", func(t *testing.T) {
-		c, err := NewConnection(Config{
+		c, err := NewInternalConnection(Config{
 			GroupID: "test-app",
 			Domain:  "example.com", // doesn't matter for this case
 			AuthTokenProvider: func() ([]byte, error) {
@@ -214,7 +214,7 @@ func Test_ConnectAlreadyConnected(t *testing.T) {
 
 	u, _ := url.Parse(s.URL)
 
-	c, err := NewConnection(Config{
+	c, err := NewInternalConnection(Config{
 		GroupID: "test-client",
 		Domain:  u.Host,
 		APIKeyProvider: func() ([]byte, error) {
@@ -238,7 +238,7 @@ func Test_ConnectAlreadyConnected(t *testing.T) {
 }
 
 func Test_ConnectAuthTokenError(t *testing.T) {
-	c, err := NewConnection(Config{
+	c, err := NewInternalConnection(Config{
 		GroupID: "test-client",
 		Domain:  "example.com",
 		APIKeyProvider: func() ([]byte, error) {
@@ -263,7 +263,7 @@ func Test_ConsumeError(t *testing.T) {
 
 	u, _ := url.Parse(s.URL)
 
-	c, err := NewConnection(Config{
+	c, err := NewInternalConnection(Config{
 		GroupID: "test-client",
 		Domain:  u.Host,
 		APIKeyProvider: func() ([]byte, error) {
@@ -305,7 +305,7 @@ func Test_ConsumeError(t *testing.T) {
 }
 
 func Test_PublishError1(t *testing.T) {
-	c, err := NewConnection(Config{
+	c, err := NewInternalConnection(Config{
 		GroupID: "test-client",
 		Domain:  "example.com",
 		APIKeyProvider: func() ([]byte, error) {
@@ -330,7 +330,7 @@ func Test_PublishError2(t *testing.T) {
 
 	u, _ := url.Parse(s.URL)
 
-	c, err := NewConnection(Config{
+	c, err := NewInternalConnection(Config{
 		GroupID: "test-client",
 		Domain:  u.Host,
 		APIKeyProvider: func() ([]byte, error) {
@@ -368,7 +368,7 @@ func Test_PublishAsync(t *testing.T) {
 
 	u, _ := url.Parse(s.URL)
 
-	c, err := NewConnection(Config{
+	c, err := NewInternalConnection(Config{
 		GroupID: "test-client",
 		Domain:  u.Host,
 		APIKeyProvider: func() ([]byte, error) {
@@ -423,7 +423,7 @@ func Test_PublishAsyncCanceled(t *testing.T) {
 
 	u, _ := url.Parse(s.URL)
 
-	c, err := NewConnection(Config{
+	c, err := NewInternalConnection(Config{
 		GroupID: "test-client",
 		Domain:  u.Host,
 		APIKeyProvider: func() ([]byte, error) {
@@ -480,7 +480,7 @@ func Test_ConsumeTimeout(t *testing.T) {
 
 	u, _ := url.Parse(s.URL)
 
-	c, err := NewConnection(Config{
+	c, err := NewInternalConnection(Config{
 		GroupID: "test-client",
 		Domain:  u.Host,
 		APIKeyProvider: func() ([]byte, error) {

--- a/internal/pubsub/message.go
+++ b/internal/pubsub/message.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cisco-pxgrid/cloud-sdk-go/log"
 )
 
-func (c *Connection) sendOpenMessage() error {
+func (c *internalConnection) sendOpenMessage() error {
 	req, err := rpc.NewOpenRequest(c.config.GroupID)
 	if err != nil {
 		return err
@@ -19,7 +19,7 @@ func (c *Connection) sendOpenMessage() error {
 	return c.sendControlMessage(req)
 }
 
-func (c *Connection) sendCloseMessage() error {
+func (c *internalConnection) sendCloseMessage() error {
 	req, err := rpc.NewCloseRequest(c.config.GroupID)
 	if err != nil {
 		return err
@@ -27,7 +27,7 @@ func (c *Connection) sendCloseMessage() error {
 	return c.sendControlMessage(req)
 }
 
-func (c *Connection) sendControlMessage(req *rpc.Request) error {
+func (c *internalConnection) sendControlMessage(req *rpc.Request) error {
 	log.Logger.Debugf("Sending control message: %v", req)
 	respCh := make(chan *rpc.Response, 1) // we expect 1 response back
 	err := c.sendMessage(req, func(resp *rpc.Response) {
@@ -52,7 +52,7 @@ func (c *Connection) sendControlMessage(req *rpc.Request) error {
 	return nil
 }
 
-func (c *Connection) sendMessage(req *rpc.Request, handler func(resp *rpc.Response)) error {
+func (c *internalConnection) sendMessage(req *rpc.Request, handler func(resp *rpc.Response)) error {
 	select {
 	case c.writerCh <- &msgRequest{req: req, handler: handler}:
 		return nil

--- a/internal/pubsub/publish.go
+++ b/internal/pubsub/publish.go
@@ -33,7 +33,7 @@ func (p *PublishResult) String() string {
 	return fmt.Sprintf("PublishResult[ID: %s, Error: %v]", p.ID, p.Error)
 }
 
-func (c *Connection) sendPublishMessage(stream string, headers map[string]string, payload string, ack *pubResultAck) (string, error) {
+func (c *internalConnection) sendPublishMessage(stream string, headers map[string]string, payload string, ack *pubResultAck) (string, error) {
 	// Create a new request for publishing the message
 	req, err := rpc.NewPublishRequest(stream, headers, payload)
 	if err != nil {
@@ -88,7 +88,7 @@ func (c *Connection) sendPublishMessage(stream string, headers map[string]string
 }
 
 // Publish publishes a message to the stream asynchronously.
-func (c *Connection) Publish(ctx context.Context, stream string, headers map[string]string, payload []byte) (*PublishResult, error) {
+func (c *internalConnection) Publish(ctx context.Context, stream string, headers map[string]string, payload []byte) (*PublishResult, error) {
 	ack := &pubResultAck{
 		ch: make(chan *PublishResult),
 	}
@@ -107,7 +107,7 @@ func (c *Connection) Publish(ctx context.Context, stream string, headers map[str
 
 // PublishAsync publishes a message to the stream asynchronously.
 // Response can be monitored on the supplied channel. The cancel function must be invoked before closing the channel.
-func (c *Connection) PublishAsync(stream string, headers map[string]string, payload []byte, result chan *PublishResult) (msgID string, cancel func(), err error) {
+func (c *internalConnection) PublishAsync(stream string, headers map[string]string, payload []byte, result chan *PublishResult) (msgID string, cancel func(), err error) {
 	ack := &pubResultAck{
 		ch: result,
 	}

--- a/internal/pubsub/reconnect.go
+++ b/internal/pubsub/reconnect.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2022, Cisco Systems, Inc.
+// All rights reserved.
+
+package pubsub
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cisco-pxgrid/cloud-sdk-go/log"
+)
+
+// Connection represents a connection to the DxHub PubSub server.
+// WORKAROUND This is a wrapper for original Connection
+// The original Connection is now renamed to internalConnection
+// This reconnects in case of the server message drop issue.
+// When server issue is fixed, InternalConnection will be reverted back to Connection.
+type Connection struct {
+	config        Config
+	conn          *internalConnection
+	Error         chan error
+	ctx           context.Context
+	ctxCancel     context.CancelFunc
+	subscriptions map[string]subscriptionParams
+}
+
+type subscriptionParams struct {
+	stream         string
+	subscriptionID string
+	handler        SubscriptionCallback
+}
+
+// NewConnection creates a new connection object based on the supplied configuration.
+func NewConnection(config Config) (*Connection, error) {
+	conn, err := NewInternalConnection(config)
+	if err != nil {
+		return nil, err
+	}
+	c := &Connection{
+		config:        config,
+		conn:          conn,
+		Error:         make(chan error, 1),
+		subscriptions: map[string]subscriptionParams{},
+	}
+	return c, nil
+}
+
+func (c *Connection) String() string {
+	return fmt.Sprintf("Conn[ID: %s, Domain: %s]", c.config.GroupID, c.config.Domain)
+}
+
+// Connect establishes a connection to the DxHub PubSub server.
+func (c *Connection) Connect(connectCtx context.Context) error {
+	if err := c.conn.Connect(connectCtx); err != nil {
+		return err
+	}
+	c.ctx, c.ctxCancel = context.WithCancel(context.Background())
+	go c.errorHandler()
+	return nil
+}
+
+// Disconnect disconnects the connection to the DxHub PubSub server.
+func (c *Connection) Disconnect() {
+	c.ctxCancel()
+	if c.conn != nil {
+		c.conn.Disconnect()
+	}
+}
+
+// IsDisconnected returns true if c is disconnected from the server.
+func (c *Connection) IsDisconnected() bool {
+	return c.conn.IsDisconnected()
+}
+
+// Subscribe subscribes to a DxHub Pubsub Stream
+func (c *Connection) Subscribe(stream string, handler SubscriptionCallback) error {
+	subscriptionID, err := c.conn.Subscribe(stream, "", handler)
+	if err != nil {
+		return err
+	}
+	sub := subscriptionParams{
+		stream:         stream,
+		subscriptionID: subscriptionID,
+		handler:        handler,
+	}
+	c.subscriptions[stream] = sub
+	return nil
+}
+
+// Unsubscribe unsubscribes from a DxHub Pubsub Stream
+func (c *Connection) Unsubscribe(stream string) error {
+	if err := c.conn.Unsubscribe(stream); err != nil {
+		return err
+	}
+	delete(c.subscriptions, stream)
+	return nil
+}
+
+// Publish publishes a message to the stream asynchronously.
+func (c *Connection) Publish(ctx context.Context, stream string, headers map[string]string, payload []byte) (*PublishResult, error) {
+	return c.conn.Publish(ctx, stream, headers, payload)
+}
+
+// PublishAsync publishes a message to the stream asynchronously.
+// Response can be monitored on the supplied channel. The cancel function must be invoked before closing the channel.
+func (c *Connection) PublishAsync(stream string, headers map[string]string, payload []byte, result chan *PublishResult) (msgID string, cancel func(), err error) {
+	return c.conn.PublishAsync(stream, headers, payload, result)
+}
+
+// errorHandler waits for error and puts it in the error channel
+// If there is message drop, ConsumeTimeout will be true,
+// it reconnects and resubscribes
+func (c *Connection) errorHandler() {
+	var err error
+	defer func() {
+		// Always push the err, even if it is nil
+		c.Error <- err
+	}()
+	for {
+		select {
+		case err = <-c.conn.Error:
+			if !c.conn.ConsumeTimeout {
+				return
+			}
+			log.Logger.Warnf("Consume timeout. Reconnecting")
+			// Create new connection and subscribe with existing subscription ID
+			c.conn, err = NewInternalConnection(c.config)
+			if err != nil {
+				return
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			if err = c.conn.Connect(ctx); err != nil {
+				return
+			}
+			for _, sub := range c.subscriptions {
+				_, err = c.conn.Subscribe(sub.stream, sub.subscriptionID, sub.handler)
+				if err != nil {
+					return
+				}
+			}
+		case <-c.ctx.Done():
+			return
+		}
+	}
+}


### PR DESCRIPTION
Rewrite the message drop workaround so the changes are within pubsub package only:
- Renamed original Connection to internalConnection
  - Functions for internalConnection are not renamed since the struct is not public
  - And changing its functions to lowercase may cause a lot of conflict. e.g. There are Unsubscribe and unsubscribe.
- Created a new Connection object to wrap the original
  - This intercepts the error channel
  - It will reconnect if message drop occurs
- app.go outside of the pubsub package is reverted back to before the workaround was introduced