### PR TITLE
CSCwd08548 : pxGrid Cloud SDK documentation missing reconnect handling

### DIFF
--- a/app.go
+++ b/app.go
@@ -44,7 +44,7 @@ var tlsConfig = tls.Config{
 // Credentials required to be stored securely
 type Credentials struct {
 	// ApiKey is obtained during app onboarding with dragonfly
-	// ApiKey will be not zeroed since it is required for reconnect
+	// ApiKey will be zeroed after use, therefore AppConfig.GetCredentials function should provide new structure every invocation
 	ApiKey []byte
 }
 
@@ -137,6 +137,7 @@ func New(config Config) (*App, error) {
 			}
 
 			request.SetHeader("X-API-KEY", string(credentials.ApiKey))
+			zeroByteArray(credentials.ApiKey)
 			return nil
 		})
 

--- a/app.go
+++ b/app.go
@@ -44,7 +44,7 @@ var tlsConfig = tls.Config{
 // Credentials required to be stored securely
 type Credentials struct {
 	// ApiKey is obtained during app onboarding with dragonfly
-	// ApiKey will be zeroed after use, therefore AppConfig.GetCredentials function should provide new structure every invocation
+	// ApiKey will be not zeroed since it is required for reconnect
 	ApiKey []byte
 }
 
@@ -137,7 +137,6 @@ func New(config Config) (*App, error) {
 			}
 
 			request.SetHeader("X-API-KEY", string(credentials.ApiKey))
-			zeroByteArray(credentials.ApiKey)
 			return nil
 		})
 

--- a/app.go
+++ b/app.go
@@ -1,4 +1,4 @@
-package main
+package cloud
 
 import (
 	"context"

--- a/app_test.go
+++ b/app_test.go
@@ -66,9 +66,6 @@ func (suite *AppTestSuite) SetupTest() {
 	})
 	u, _ := url.Parse(s.URL)
 
-	credentials := Credentials{
-		ApiKey: []byte("xyz"),
-	}
 	suite.config = Config{
 		ID:            "appId",
 		RegionalFQDN:  u.Host,
@@ -76,7 +73,9 @@ func (suite *AppTestSuite) SetupTest() {
 		WriteStreamID: "writeStream",
 		ReadStreamID:  "readStream",
 		GetCredentials: func() (*Credentials, error) {
-			return &credentials, nil
+			return &Credentials{
+				ApiKey: []byte("api-key-obtained-during-app-onboarding"),
+			}, nil
 		},
 		DeviceActivationHandler: func(device *Device) {
 		},

--- a/internal/pubsub/reconnect.go
+++ b/internal/pubsub/reconnect.go
@@ -58,7 +58,9 @@ func (c *Connection) Connect(connectCtx context.Context) error {
 
 // Disconnect disconnects the connection to the DxHub PubSub server.
 func (c *Connection) Disconnect() {
-	c.ctxCancel()
+	if c.ctx != nil {
+		c.ctxCancel()
+	}
 	if c.conn != nil {
 		c.conn.disconnect()
 	}


### PR DESCRIPTION
Issue: pxGrid Cloud SDK documentation missing reconnect handling

Solution: Introduced a reconnect logic in SDK itself.

Unit Tests:

Tested and confirmed the following scenarios:
1. When Server goes down, the sdk keep on trying to reconnect with granular retry mechanism.
2. When server comes up, reconnect to cloud after connection failure with granular retry is successful.
3. When websocket closed by server, sdk reonnect happens

Attached the logs for reference.
[Unit test for CSCwd08548 pxGrid Cloud SDK documentation missing reconnect handling.txt](https://github.com/cisco-pxgrid/cloud-sdk-go/files/10067969/Unit.test.for.CSCwd08548.pxGrid.Cloud.SDK.documentation.missing.reconnect.handling.txt)

Ran UT and confirmed that all pass.
[root@cadev-hcl6 cloud-sdk-go]# go test -v
=== RUN   TestAppTestSuite
=== RUN   TestAppTestSuite/TestLinkTenant
=== RUN   TestAppTestSuite/TestNew
2022/11/24 19:47:42 | ERROR | cloud-sdk-go/app.go:173 | Failed to connect the app: failed to open pubsub connect: failed to connect: failed to WebSocket dial: failed to send handshake request: Get "https://127.0.0.1:45693/api/v2/pubsub": net/http: invalid header field value "\x00\x00\x00" for key X-Api-Key
2022/11/24 19:47:42 | DEBUG | pubsub/connection.go:360 | Connection is not opened
=== RUN   TestAppTestSuite/TestSetTenant
=== RUN   TestAppTestSuite/TestUnlinkTenant
=== RUN   TestAppTestSuite/TestUnlinkTenant_Error
2022/11/24 19:47:42 | ERROR | cloud-sdk-go/app.go:173 | Failed to connect the app: failed to open pubsub connect: failed to connect: failed to WebSocket dial: failed to send handshake request: Get "https://127.0.0.1:42433/api/v2/pubsub": net/http: invalid header field value "\x00\x00\x00" for key X-Api-Key
2022/11/24 19:47:42 | DEBUG | pubsub/connection.go:360 | Connection is not opened
--- PASS: TestAppTestSuite (0.00s)
    --- PASS: TestAppTestSuite/TestLinkTenant (0.00s)
    --- PASS: TestAppTestSuite/TestNew (0.00s)
    --- PASS: TestAppTestSuite/TestSetTenant (0.00s)
    --- PASS: TestAppTestSuite/TestUnlinkTenant (0.00s)
    --- PASS: TestAppTestSuite/TestUnlinkTenant_Error (0.00s)
=== RUN   TestDeviceTestSuite
2022/11/24 19:47:42 | ERROR | cloud-sdk-go/app.go:173 | Failed to connect the app: failed to open pubsub connect: failed to connect: failed to WebSocket dial: failed to send handshake request: Get "https://127.0.0.1:45595/api/v2/pubsub": net/http: invalid header field value "\x00\x00\x00" for key X-Api-Key
2022/11/24 19:47:42 | DEBUG | pubsub/connection.go:360 | Connection is not opened
=== RUN   TestDeviceTestSuite/TestGetDeviceStatus
=== RUN   TestDeviceTestSuite/TestQuery
--- PASS: TestDeviceTestSuite (0.00s)
    --- PASS: TestDeviceTestSuite/TestGetDeviceStatus (0.00s)
    --- PASS: TestDeviceTestSuite/TestQuery (0.00s)
=== RUN   TestTenantTestSuite
=== RUN   TestTenantTestSuite/TestGetDeviceByID
=== RUN   TestTenantTestSuite/TestGetDevices
    tenant_test.go:46: Expected: [{1     <nil>} {2     <nil>}]  Received:  [{1     <nil>} {2     <nil>}]
=== RUN   TestTenantTestSuite/Test_getDeviceByID
=== RUN   TestTenantTestSuite/Test_getDevices
--- PASS: TestTenantTestSuite (0.00s)
    --- PASS: TestTenantTestSuite/TestGetDeviceByID (0.00s)
    --- PASS: TestTenantTestSuite/TestGetDevices (0.00s)
    --- PASS: TestTenantTestSuite/Test_getDeviceByID (0.00s)
    --- PASS: TestTenantTestSuite/Test_getDevices (0.00s)
PASS
ok      github.com/cisco-pxgrid/cloud-sdk-go    0.011s
[root@cadev-hcl6 cloud-sdk-go]# 