### PR TITLE
ObjectStore update

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -48,7 +48,7 @@ func setupTestserver() (*httptest.Server, *chi.Mux) {
 		devices := []getDeviceResponse{d}
 		render.JSON(w, r, devices)
 	})
-	r.Post(objectStorePath, func(w http.ResponseWriter, r *http.Request) {})
+	r.Put(objectStorePath, func(w http.ResponseWriter, r *http.Request) {})
 	r.Get(objectStorePath, func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("object1")) })
 	r.Get(pubsubPath, func(w http.ResponseWriter, r *http.Request) {
 		conn, _ := websocket.Accept(w, r, nil)


### PR DESCRIPTION
This is for using the S3 link directly
- An update is required because S3 does not support chunk encoding
- Also, the upload is PUT instead of POST
- Limiting the request object to 100MB