### PR TITLE
Workaround slow callback handling

### DIFF
--- a/internal/pubsub/connection.go
+++ b/internal/pubsub/connection.go
@@ -60,6 +60,7 @@ import (
 	"time"
 
 	rpc "github.com/cisco-pxgrid/cloud-sdk-go/internal/rpc"
+	"github.com/google/uuid"
 
 	"github.com/cisco-pxgrid/cloud-sdk-go/log"
 	"github.com/cisco-pxgrid/websocket"
@@ -121,6 +122,7 @@ type internalConnection struct {
 	// returned from the channel shall describe the reason of connection closure. A nil value
 	// indicates normal closure.
 	Error      chan error
+	id         string
 	mu         sync.Mutex       // lock to protect the connection itself
 	config     Config           // config received from the user
 	restClient *resty.Client    // resty HTTP client
@@ -162,6 +164,7 @@ func newInternalConnection(config Config) (*internalConnection, error) {
 	}
 	c := &internalConnection{
 		config:      config,
+		id:          uuid.New().String(),
 		restClient:  httpClient,
 		closed:      make(chan struct{}),
 		Error:       make(chan error, 1),        // buffer of 1 to make sure that error is not lost

--- a/internal/pubsub/connection_test.go
+++ b/internal/pubsub/connection_test.go
@@ -299,7 +299,6 @@ func Test_ConsumeError(t *testing.T) {
 	c.disconnect()
 
 	require.True(t, c.isDisconnected())
-	require.Zero(t, len(c.subs.table))
 	require.Zero(t, count)
 }
 

--- a/internal/pubsub/message.go
+++ b/internal/pubsub/message.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (c *internalConnection) sendOpenMessage() error {
-	req, err := rpc.NewOpenRequest(c.config.GroupID)
+	req, err := rpc.NewOpenRequest(c.id)
 	if err != nil {
 		return err
 	}
@@ -20,7 +20,7 @@ func (c *internalConnection) sendOpenMessage() error {
 }
 
 func (c *internalConnection) sendCloseMessage() error {
-	req, err := rpc.NewCloseRequest(c.config.GroupID)
+	req, err := rpc.NewCloseRequest(c.id)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is a workaround because cloud does not disconnect external websocket even internal connection is gone.
Cloud team will look into the fix.

The workaround in details:
- To have a timeout on processing delay to ensure timely consume request
- To process one message ahead so current message is acknowledged
- Log inactivity every 10m