### PR TITLE
Fixed app instance missing group ID

### DIFF
--- a/appinstance.go
+++ b/appinstance.go
@@ -137,6 +137,7 @@ func (app *App) newAppConfig(appID, appApiKey string) Config {
 		RegionalFQDN:              app.config.RegionalFQDN,
 		ReadStreamID:              "app--" + appID + "-R",
 		WriteStreamID:             "app--" + appID + "-W",
+		GroupID:                   app.config.GroupID,
 		Transport:                 app.config.Transport,
 		ApiKey:                    appApiKey,
 		DeviceActivationHandler:   app.config.DeviceActivationHandler,

--- a/examples/basic-consumer/main.go
+++ b/examples/basic-consumer/main.go
@@ -82,6 +82,8 @@ func main() {
 	configFile := flag.String("config", "", "Configuration yaml file to use (required)")
 	debug := flag.Bool("debug", false, "Enable debug output")
 	insecure := flag.Bool("insecure", false, "Insecure TLS")
+	group := flag.String("group", "", "Group ID")
+
 	flag.Parse()
 	config, err := loadConfig(*configFile)
 	if err != nil {
@@ -115,7 +117,7 @@ func main() {
 		DeviceMessageHandler:      messageHandler,
 		ReadStreamID:              config.App.ReadStream,
 		WriteStreamID:             config.App.WriteStream,
-		GroupID:                   config.App.GroupId,
+		GroupID:                   *group,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: *insecure,

--- a/examples/multi-instance/main.go
+++ b/examples/multi-instance/main.go
@@ -87,6 +87,7 @@ func main() {
 	configFile := flag.String("config", "", "Configuration yaml file to use (required)")
 	debug := flag.Bool("debug", false, "Enable debug output")
 	insecure := flag.Bool("insecure", false, "Insecure TLS")
+	group := flag.String("group", "", "Group ID")
 	deleteInstance := flag.Bool("delete", false, "Delete app instance")
 	flag.Parse()
 	config, err := loadConfig(*configFile)
@@ -120,6 +121,7 @@ func main() {
 		DeviceMessageHandler:      messageHandler,
 		ReadStreamID:              config.App.ReadStream,
 		WriteStreamID:             config.App.WriteStream,
+		GroupID:                   *group,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: *insecure,


### PR DESCRIPTION
The group ID configured for the App did not get carried over to the App Instances.
So it was always commonGroup (and prior to v0.5.16, it was always random)