### PR TITLE
Change groupId back to unique if not specified, like original code

### DIFF
--- a/app.go
+++ b/app.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cisco-pxgrid/cloud-sdk-go/internal/pubsub"
 	"github.com/cisco-pxgrid/cloud-sdk-go/log"
 	"github.com/go-resty/resty/v2"
+	"github.com/rs/xid"
 )
 
 const (
@@ -75,7 +76,7 @@ type Config struct {
 
 	// GroupID defines the group in which this instance of the App belongs to. Instances that belong
 	// in the same group gets messages distributed between them. Instances that belong in separate
-	// groups get a copy of each message. If left empty, unique ID will be used.
+	// groups get a copy of each message. If left empty, unique ID will be created.
 	//
 	// e.g. There are 3 messages on the app's stream - msg1, msg2, msg3
 	//
@@ -221,7 +222,8 @@ func validateConfig(config *Config) error {
 	}
 
 	if config.GroupID == "" {
-		config.GroupID = "commonGroup"
+		// Default to create unique ID so it behaves like pubsub instead of distributed messaging
+		config.GroupID = xid.New().String()
 	}
 
 	return nil

--- a/internal/pubsub/connection.go
+++ b/internal/pubsub/connection.go
@@ -222,7 +222,7 @@ func (c *internalConnection) connect(ctx context.Context) error {
 		}
 		return fmt.Errorf("failed to connect: %v", err)
 	}
-	log.Logger.Infof("Connected to PubSub server: %s", brokerSubURL.String())
+	log.Logger.Infof("Connected to PubSub server. url=%s groupId=%s", brokerSubURL.String(), c.config.GroupID)
 	c.ws.SetReadLimit(maxMessageSize)
 
 	c.wg.Add(1)

--- a/internal/pubsub/subscribe.go
+++ b/internal/pubsub/subscribe.go
@@ -51,7 +51,7 @@ func (c *internalConnection) subscribe(stream string, subscriptionID string, han
 		if err != nil {
 			return "", fmt.Errorf("failed to create subscription for %s: %v", stream, err)
 		}
-		log.Logger.Infof("Created subscription ID=%s", id)
+		log.Logger.Infof("Created subscription. id=%s stream=%s", id, stream)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
This changes back the original behavior where unspecified groupId to get messages like pubsub way instead of Kafka load distributed way.