### PR TITLE
Fix tenant removed after reconnection

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -15,67 +15,57 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func init() {
-	// Speed up for testing
-
-}
-
 func TestReconnect(t *testing.T) {
+	// Prepare test
 	reconnectBackoff = 1 * time.Second
 	reconnectDelay = 1 * time.Second
-
+	message := `{
+					"readStream":[
+						{
+							"msgId": "msg1",
+							"headers": {
+								"messageType": "data",
+								"tenant": "tenant1",
+								"device": "device1",
+								"key1": "val1"
+							},
+							"payload": "VGhpcyBpcyBhIHRlc3Q="
+						}
+					]
+				}`
+	var messageChan = make(chan string, 1)
+	var closeChan = make(chan struct{}, 1)
 	var connCount atomic.Uint32
-	var consumeCount int
 	s, _ := test.NewRPCServer(t, test.Config{
 		ConnHandler: func() int {
 			connCount.Add(1)
 			return http.StatusOK
 		},
 		ConsumeHandler: func(conn *websocket.Conn, req *rpc.Request) *rpc.Response {
-			consumeCount++
-			if consumeCount == 1 {
-				result := `{
-					"consumeContext": "ctx1",
-					"subscriptionId": "sub1",
-					"messages": {
-						"readStream":[
-							{
-								"msgId": "msg1",
-								"headers": {
-									"messageType": "data",
-									"tenant": "tenant1",
-									"device": "device1",
-									"key1": "val2"
-								},
-								"payload": "VGhpcyBpcyBhIHRlc3Q="
-							}
-						]
-					}
-				}`
-				return &rpc.Response{
-					Version: "1.0",
-					ID:      req.ID,
-					Result:  json.RawMessage(result),
-				}
-			} else if consumeCount == 2 {
-				// close the connection to trigger reconnect
+			var payload string
+			select {
+			case <-closeChan:
 				conn.Close(websocket.StatusNormalClosure, "")
 				return nil
-			} else {
-				result := `{
+			case payload = <-messageChan:
+			default:
+				payload = "{}"
+			}
+			result := `{
 					"consumeContext": "ctx1",
-					"subscriptionId": "readStream",
-					"messages": {}
-				}`
-				return &rpc.Response{
-					Version: "1.0",
-					ID:      req.ID,
-					Result:  json.RawMessage(result),
-				}
+					"subscriptionId": "sub1",
+					"messages":` + payload + `}`
+			return &rpc.Response{
+				Version: "1.0",
+				ID:      req.ID,
+				Result:  json.RawMessage(result),
 			}
 		},
 	})
 	defer s.Close()
+
+	// Create New app
+	var messageCount atomic.Uint32
 	u, _ := url.Parse(s.URL)
 	config := Config{
 		ID:            "appId",
@@ -91,13 +81,43 @@ func TestReconnect(t *testing.T) {
 				InsecureSkipVerify: true,
 			},
 		},
+		DeviceMessageHandler: func(messageID string, device *Device, stream string, payload []byte) {
+			messageCount.Add(1)
+		},
 	}
 	app, err := New(config)
 	require.NoError(t, err)
-	tenant, err := app.LinkTenant("otp_string")
+	tenant, err := app.LinkTenant("dummy")
 	require.NoError(t, err)
-	// wait for the connection to be established
+
+	// wait until devices are populated
+	require.Eventually(t, func() bool {
+		devices, err := tenant.GetDevices()
+		require.NoError(t, err)
+		return len(devices) == 1
+	}, 5*time.Second, 1*time.Second)
+
+	// Check received messages
+	messageChan <- message
+	require.Eventually(t, func() bool { return messageCount.Load() == 1 }, 5*time.Second, 1*time.Second)
+
+	// Check reconnect
+	require.True(t, connCount.Load() == 1)
+	closeChan <- struct{}{}
+	// wait for the connection to be re-established
 	require.Eventually(t, func() bool { return connCount.Load() == 2 }, 5*time.Second, 1*time.Second)
+
+	// wait until devices are populated
+	require.Eventually(t, func() bool {
+		devices, err := tenant.GetDevices()
+		require.NoError(t, err)
+		return len(devices) == 1
+	}, 5*time.Second, 1*time.Second)
+
+	// Check received messages after reconnect
+	messageChan <- message
+	require.Eventually(t, func() bool { return messageCount.Load() == 2 }, 5*time.Second, 1*time.Second)
+
 	_ = app.UnlinkTenant(tenant)
 	app.Close()
 }

--- a/examples/basic-consumer/main.go
+++ b/examples/basic-consumer/main.go
@@ -130,6 +130,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	defer app.Close()
 	logger.Debugf("App config: %+v", appConfig)
 
 	var tc = &config.Tenant
@@ -160,13 +161,13 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	select {
-	case <-ctx.Done():
-		logger.Infof("Terminating...")
-	case err := <-app.Error:
-		logger.Errorf("App error: %v", err)
-	}
-	if err = app.Close(); err != nil {
-		panic(err)
+	for {
+		select {
+		case err := <-app.Error:
+			logger.Errorf("App error: %v", err)
+		case <-ctx.Done():
+			logger.Infof("Terminating...")
+			return
+		}
 	}
 }

--- a/internal/pubsub/test/server.go
+++ b/internal/pubsub/test/server.go
@@ -248,13 +248,13 @@ func NewRPCServer(t *testing.T, cfg Config) (*httptest.Server, *chi.Mux) {
 	r.Get("/api/uno/v1/registry/devices", func(w http.ResponseWriter, r *http.Request) {
 		u, _ := url.Parse(ts.URL)
 		resp := getDeviceResponse{
-			ID: "dev1",
+			ID: "device1",
 			DeviceInfo: struct {
 				Kind string `json:"deviceType"`
 				Name string `json:"name"`
 			}{
 				Kind: "cisco-ise",
-				Name: "sjc-511-1",
+				Name: "device1",
 			},
 			MgtInfo: struct {
 				Region string `json:"region"`


### PR DESCRIPTION
Previous reconnection fix had revealed further issues.
Tenants that were added by setTenant were removed during the reconnection process.
Because of this, the app was unable to get any message because incoming messages did not match any tenant. Also, making API calls will result in "invalid tenant id", again because the tenant was missing in the list.

The fix is NOT to clear the tenant list. The device map will be refreshed once the reconnection completes.
The UT now ensure messages received after reconnection are processed properly.
Manually tests by suspending basic-consumer and echo-query, thus causing a reconnection, also proved messages could be received and API can be called after the reconnection.